### PR TITLE
Potential fix for an issue due to reliance on relative date

### DIFF
--- a/src/SparkLine.php
+++ b/src/SparkLine.php
@@ -169,8 +169,11 @@ final class SparkLine
             ->map(fn (int $days) => (new DateTimeImmutable("-{$days} days"))->format('Y-m-d'))
             ->reverse()
             ->mapWithKeys(function (string $key) {
+                $interval = (new DateTimeImmutable($key))->diff(new DateTimeImmutable());
+                $index = $interval->days;
+
                 /** @var SparkLineDay|null $day */
-                $day = $this->days[$key] ?? null;
+                $day = $this->days->reverse()->values()[$index] ?? null;
 
                 return [
                     $key => $day


### PR DESCRIPTION
Fixes #4 an issue where the SparkLine will only show SparkLineDay objects whose date does not differ from the current date by more than X days. Where X is the number of SparkLineDay objects passed into the SparkLine object (maxItemAmount).

That is because inside the resolveCoordinates method a collection of dates is created that is relative to the current date. Then those dates are used to find entries in the collection of SparkLineDay objects whose dates are not guaranteed to be relative to the current date.

This commit changed the way the SparkLineDay object of a day is retrieved by relying on the sort order of the $days collection.